### PR TITLE
Fix ApplyChanges when old and new are different len

### DIFF
--- a/internal/provider/domeneshop.go
+++ b/internal/provider/domeneshop.go
@@ -89,21 +89,38 @@ func (p *Provider) ApplyChanges(body io.ReadCloser) (error string) {
 			continue
 		}
 
-		// Loop over all targets
-		for targetIndex, target := range record.Targets {
+		oldTargets := make(map[string]bool, len(oldRecord.Targets))
+		for _, t := range oldRecord.Targets {
+			oldTargets[t] = true
+		}
+		newTargets := make(map[string]bool, len(record.Targets))
+		for _, t := range record.Targets {
+			newTargets[t] = true
+		}
 
-			oldTarget := oldRecord.Targets[targetIndex]
-
-			// Convert to Domeneshop Domain-structs
-			oldDnsRecord := endpointToDnsRecord(domainZone, oldRecord, oldTarget)
-			newDnsRecord := endpointToDnsRecord(domainZone, record, target)
-
-			// Call appropriate Domeneshop-function
-			ok := p.domeneshopClient.UpdateRecord(domainZone, oldDnsRecord, newDnsRecord)
-			if !ok {
+		for _, t := range oldRecord.Targets {
+			if newTargets[t] {
+				continue
+			}
+			if err := p.domeneshopClient.DeleteRecord(domainZone, endpointToDnsRecord(domainZone, oldRecord, t)); err != nil {
 				return "StatusInternalServerError"
 			}
-
+		}
+		for _, t := range record.Targets {
+			newR := endpointToDnsRecord(domainZone, record, t)
+			if !oldTargets[t] {
+				if !p.domeneshopClient.CreateRecord(domainZone, newR) {
+					return "StatusInternalServerError"
+				}
+				continue
+			}
+			oldR := endpointToDnsRecord(domainZone, oldRecord, t)
+			if oldR == newR {
+				continue
+			}
+			if !p.domeneshopClient.UpdateRecord(domainZone, oldR, newR) {
+				return "StatusInternalServerError"
+			}
 		}
 
 	}


### PR DESCRIPTION
If there is an old DNS record, but with a differing number of values than the new one, the `ApplyChanges` function will fail.

```
2026/05/15 17:57:08 http: panic serving 127.0.0.1:41934: runtime error: index out of range [1] with length 1                                          
goroutine 742 [running]:                                                                                                                              
net/http.(*conn).serve.func1()                                                                                                                        
    net/http/server.go:1898 +0xbe                                                                                                                     
panic({0x7b2b00?, 0xc000140420?})                                                                                                                     
    runtime/panic.go:770 +0x132                                                                                                                       
github.com/vidarno/external-dns-domeneshop-webhook/internal/provider.(*Provider).ApplyChanges(0xc0000a0490, {0x881b38, 0xc000288a00})                 
    github.com/vidarno/external-dns-domeneshop-webhook/internal/provider/domeneshop.go:95 +0x739                                                      
github.com/vidarno/external-dns-domeneshop-webhook/pkg/webhook.(*Webhook).Records(0xc0000a0490, {0x8838d8, 0xc00014ca80}, 0xc000258120)               
    github.com/vidarno/external-dns-domeneshop-webhook/pkg/webhook/webhook.go:72 +0x115                                                               
net/http.HandlerFunc.ServeHTTP(0xc00017a300?, {0x8838d8?, 0xc00014ca80?}, 0x10?)                                                                      
    net/http/server.go:2166 +0x29                                                                                                                     
net/http.(*ServeMux).ServeHTTP(0x40ea65?, {0x8838d8, 0xc00014ca80}, 0xc000258120)                                                                     
    net/http/server.go:2683 +0x1ad                                                                                                                    
net/http.serverHandler.ServeHTTP({0x881b38?}, {0x8838d8?, 0xc00014ca80?}, 0x6?)                                                                       
    net/http/server.go:3137 +0x8e                                                                                                                     
net/http.(*conn).serve(0xc0000e8750, {0x884c30, 0xc000186720})                                                                                        
    net/http/server.go:2039 +0x5e8                                                                                                                    
created by net/http.(*Server).Serve in goroutine 20                                                                                                   
    net/http/server.go:3285 +0x4b4
```

This PR fixes it by making sure a record is handled properly as a set.